### PR TITLE
copy and build vignettes in docs/articles

### DIFF
--- a/R/build-articles.R
+++ b/R/build-articles.R
@@ -56,16 +56,28 @@ build_articles <- function(pkg = ".", path = "docs/articles", depth = 1L) {
   rule("Building articles")
   mkdir(path)
 
+  # copy vignette Rmds from vignettes/ to docs/articles
+  copy_article <- function(file_in, ...) {
+    vig_path <- file.path(pkg$path, "vignettes", file_in)
+    article_path <- file.path(pkg$path, path, file_in)
+    file.copy(vig_path, article_path)
+  }
+  purrr::pwalk(pkg$vignettes, copy_article)
+
+  # render them in docs/articles and remove copied Rmd files when finished
   render_article <- function(file_in, file_out, vig_depth, ...) {
     format <- build_rmarkdown_format(pkg, depth = vig_depth + depth)
     on.exit(unlink(format$path), add = TRUE)
 
+    article_path <- file.path(pkg$path, path, file_in)
+    on.exit(unlink(article_path), add = TRUE)
+
     message("Building vignette '", file_in, "'")
+
     path <- rmarkdown::render(
-      file.path(pkg$path, "vignettes", file_in),
+      article_path,
       output_format = format$format,
       output_file = basename(file_out),
-      output_dir = file.path(path, dirname(file_out)),
       quiet = TRUE,
       envir = new.env(parent = globalenv())
     )

--- a/R/build-articles.R
+++ b/R/build-articles.R
@@ -56,15 +56,13 @@ build_articles <- function(pkg = ".", path = "docs/articles", depth = 1L) {
   rule("Building articles")
   mkdir(path)
 
-  # copy vignette Rmds from vignettes/ to docs/articles
-  copy_article <- function(file_in, ...) {
-    vig_path <- file.path(pkg$path, "vignettes", file_in)
-    article_path <- file.path(pkg$path, path, file_in)
-    file.copy(vig_path, article_path)
-  }
-  purrr::pwalk(pkg$vignettes, copy_article)
+  # copy everything from vignettes/ to docs/articles
+  vig_path <- file.path(pkg$path, "vignettes")
+  article_path <- file.path(pkg$path, path)
 
-  # render them in docs/articles and remove copied Rmd files when finished
+  copy_dir(vig_path, article_path)
+
+  # render the copied Rmds in docs/articles and remove it when finished
   render_article <- function(file_in, file_out, vig_depth, ...) {
     format <- build_rmarkdown_format(pkg, depth = vig_depth + depth)
     on.exit(unlink(format$path), add = TRUE)

--- a/R/build-reference.R
+++ b/R/build-reference.R
@@ -152,6 +152,7 @@ data_reference_topic <- function(topic,
   out$examples <- as_data(
     tags$tag_examples[[1]],
     env = new.env(parent = globalenv()),
+    topic = topic$name,
     index = pkg$topics,
     current = topic$name,
     path = path

--- a/R/util.r
+++ b/R/util.r
@@ -116,7 +116,7 @@ copy_dir <- function(from, to) {
   from_dirs <- from_dirs[from_dirs != '']
 
   to_dirs <- file.path(to, from_dirs)
-  sapply(to_dirs, dir.create)
+  purrr::walk(to_dirs, dir.create)
 
   from_files <- list.files(from, recursive = TRUE, full.names = TRUE)
   from_files_rel <- list.files(from, recursive = TRUE)

--- a/R/util.r
+++ b/R/util.r
@@ -109,3 +109,18 @@ print_yaml <- function(x) {
 print.print_yaml <- function(x, ...) {
   cat(yaml::as.yaml(x), "\n", sep = "")
 }
+
+copy_dir <- function(from, to) {
+
+  from_dirs <- list.dirs(from, full.names = FALSE, recursive = TRUE)
+  from_dirs <- from_dirs[from_dirs != '']
+
+  to_dirs <- file.path(to, from_dirs)
+  sapply(to_dirs, dir.create)
+
+  from_files <- list.files(from, recursive = TRUE, full.names = TRUE)
+  from_files_rel <- list.files(from, recursive = TRUE)
+
+  to_paths <- file.path(to, from_files_rel)
+  file.copy(from_files, to_paths, overwrite = TRUE)
+}


### PR DESCRIPTION
fixes #172 

Strangely PNGs generated from the render all have the format `README-chunk_label-number.png` (e.g., `README-plot-1.png`), despite the fact that many of the images don't come from a README per se.

I couldn't find where the `README` part is coming from; I presume this is a default on the `rmarkdown` side.

I think a better filename would be `pkg$vignettes$name-chunk_label-number.png`.