### PR TITLE
pass encoding to rmarkdown::render()

### DIFF
--- a/R/build-articles.R
+++ b/R/build-articles.R
@@ -50,7 +50,7 @@
 #'   Used to adjust relative links in the navbar.
 #' @param encoding The encoding of the input files.
 #' @export
-build_articles <- function(pkg = ".", path = "docs/articles", depth = 1L, encoding = getOption("encoding")) {
+build_articles <- function(pkg = ".", path = "docs/articles", depth = 1L, encoding = "UTF-8") {
   old <- set_pkgdown_env("true")
   on.exit(set_pkgdown_env(old))
 
@@ -88,7 +88,7 @@ render_rmd <- function(pkg,
                        data = list(),
                        toc = TRUE,
                        depth = 1L,
-                       encoding = getOption("encoding")) {
+                       encoding = "UTF-8") {
   message("Building article '", output_file, "'")
 
   format <- build_rmarkdown_format(pkg, depth = depth, data = data, toc = toc)

--- a/R/build-articles.R
+++ b/R/build-articles.R
@@ -73,7 +73,7 @@ build_articles <- function(pkg = ".", path = "docs/articles", depth = 1L, encodi
     depth = pkg$vignettes$vig_depth + depth
   )
   data <- list(pagetitle = "$title$")
-  purrr::pwalk(articles, render_rmd, pkg = pkg, data = data)
+  purrr::pwalk(articles, render_rmd, pkg = pkg, data = data, encoding = encoding)
   purrr::walk(articles$input, unlink)
 
   build_articles_index(pkg, path = path, depth = depth)

--- a/R/build-articles.R
+++ b/R/build-articles.R
@@ -48,8 +48,9 @@
 #'   \code{pkg} directory.
 #' @param depth Depth of path relative to root of documentation.
 #'   Used to adjust relative links in the navbar.
+#' @param encoding The encoding of the input files.
 #' @export
-build_articles <- function(pkg = ".", path = "docs/articles", depth = 1L) {
+build_articles <- function(pkg = ".", path = "docs/articles", depth = 1L, encoding = getOption("encoding")) {
   old <- set_pkgdown_env("true")
   on.exit(set_pkgdown_env(old))
 
@@ -86,7 +87,8 @@ render_rmd <- function(pkg,
                        strip_header = FALSE,
                        data = list(),
                        toc = TRUE,
-                       depth = 1L) {
+                       depth = 1L,
+                       encoding = getOption("encoding")) {
   message("Building article '", output_file, "'")
 
   format <- build_rmarkdown_format(pkg, depth = depth, data = data, toc = toc)
@@ -98,7 +100,8 @@ render_rmd <- function(pkg,
       input,
       output_format = format$format,
       output_file = basename(output_file),
-      quiet = TRUE
+      quiet = TRUE,
+      encoding = encoding
     )
   )
   update_rmarkdown_html(path, strip_header = strip_header, depth = depth,

--- a/R/build-home.R
+++ b/R/build-home.R
@@ -24,7 +24,7 @@
 #'
 #' @inheritParams build_articles
 #' @export
-build_home <- function(pkg = ".", path = "docs", depth = 0L, encoding = getOption("encoding")) {
+build_home <- function(pkg = ".", path = "docs", depth = 0L, encoding = "UTF-8") {
   old <- set_pkgdown_env("true")
   on.exit(set_pkgdown_env(old))
 

--- a/R/build-home.R
+++ b/R/build-home.R
@@ -62,7 +62,8 @@ build_home <- function(pkg = ".", path = "docs", depth = 0L, encoding = "UTF-8")
             rmarkdown::render(
               input,
               output_options = list(html_preview = FALSE),
-              quiet = TRUE
+              quiet = TRUE,
+              encoding = encoding
             )
           },
           args = list(data$path)
@@ -77,7 +78,8 @@ build_home <- function(pkg = ".", path = "docs", depth = 0L, encoding = "UTF-8")
         depth = depth,
         data = data,
         toc = FALSE,
-        strip_header = TRUE
+        strip_header = TRUE,
+        encoding = encoding
       )
     }
   }

--- a/R/build-home.R
+++ b/R/build-home.R
@@ -24,7 +24,7 @@
 #'
 #' @inheritParams build_articles
 #' @export
-build_home <- function(pkg = ".", path = "docs", depth = 0L) {
+build_home <- function(pkg = ".", path = "docs", depth = 0L, encoding = getOption("encoding")) {
   old <- set_pkgdown_env("true")
   on.exit(set_pkgdown_env(old))
 

--- a/R/build-home.R
+++ b/R/build-home.R
@@ -58,7 +58,7 @@ build_home <- function(pkg = ".", path = "docs", depth = 0L, encoding = "UTF-8")
         # Render once so that .md is up to date
         message("Updating ", file_name, ".md")
         callr::r_safe(
-          function(input) {
+          function(input, encoding) {
             rmarkdown::render(
               input,
               output_options = list(html_preview = FALSE),
@@ -66,7 +66,10 @@ build_home <- function(pkg = ".", path = "docs", depth = 0L, encoding = "UTF-8")
               encoding = encoding
             )
           },
-          args = list(data$path)
+          args = list(
+            input = data$path,
+            encoding = encoding
+          )
         )
       }
 

--- a/R/build.r
+++ b/R/build.r
@@ -143,7 +143,7 @@ build_site <- function(pkg = ".",
                        mathjax = TRUE,
                        preview = interactive(),
                        seed = 1014,
-                       encoding = getOption("encoding")
+                       encoding = "UTF-8"
                        ) {
   old <- set_pkgdown_env("true")
   on.exit(set_pkgdown_env(old))

--- a/R/build.r
+++ b/R/build.r
@@ -142,7 +142,8 @@ build_site <- function(pkg = ".",
                        run_dont_run = FALSE,
                        mathjax = TRUE,
                        preview = interactive(),
-                       seed = 1014
+                       seed = 1014,
+                       encoding = getOption("encoding")
                        ) {
   old <- set_pkgdown_env("true")
   on.exit(set_pkgdown_env(old))
@@ -152,7 +153,7 @@ build_site <- function(pkg = ".",
 
   init_site(pkg, path)
 
-  build_home(pkg, path = path)
+  build_home(pkg, path = path, encoding = encoding)
   build_reference(pkg,
     lazy = FALSE,
     examples = examples,
@@ -162,7 +163,7 @@ build_site <- function(pkg = ".",
     path = file.path(path, "reference"),
     depth = 1L
   )
-  build_articles(pkg, path = file.path(path, "articles"), depth = 1L)
+  build_articles(pkg, path = file.path(path, "articles"), depth = 1L, encoding = encoding)
   build_news(pkg, path = file.path(path, "news"), depth = 1L)
 
   if (preview) {

--- a/man/build_articles.Rd
+++ b/man/build_articles.Rd
@@ -4,7 +4,8 @@
 \alias{build_articles}
 \title{Build articles}
 \usage{
-build_articles(pkg = ".", path = "docs/articles", depth = 1L)
+build_articles(pkg = ".", path = "docs/articles", depth = 1L,
+  encoding = getOption("encoding"))
 }
 \arguments{
 \item{pkg}{Path to source package.}
@@ -14,6 +15,8 @@ build_articles(pkg = ".", path = "docs/articles", depth = 1L)
 
 \item{depth}{Depth of path relative to root of documentation.
 Used to adjust relative links in the navbar.}
+
+\item{encoding}{The encoding of the input files.}
 }
 \description{
 Each Rmarkdown vignette in \code{vignettes/} and its subdirectories is

--- a/man/build_articles.Rd
+++ b/man/build_articles.Rd
@@ -5,7 +5,7 @@
 \title{Build articles}
 \usage{
 build_articles(pkg = ".", path = "docs/articles", depth = 1L,
-  encoding = getOption("encoding"))
+  encoding = "UTF-8")
 }
 \arguments{
 \item{pkg}{Path to source package.}

--- a/man/build_home.Rd
+++ b/man/build_home.Rd
@@ -4,7 +4,8 @@
 \alias{build_home}
 \title{Build home page}
 \usage{
-build_home(pkg = ".", path = "docs", depth = 0L)
+build_home(pkg = ".", path = "docs", depth = 0L,
+  encoding = getOption("encoding"))
 }
 \arguments{
 \item{pkg}{Path to source package.}
@@ -14,6 +15,8 @@ build_home(pkg = ".", path = "docs", depth = 0L)
 
 \item{depth}{Depth of path relative to root of documentation.
 Used to adjust relative links in the navbar.}
+
+\item{encoding}{The encoding of the input files.}
 }
 \description{
 First looks for \code{index.Rmd} or \code{README.Rmd}, then

--- a/man/build_home.Rd
+++ b/man/build_home.Rd
@@ -4,8 +4,7 @@
 \alias{build_home}
 \title{Build home page}
 \usage{
-build_home(pkg = ".", path = "docs", depth = 0L,
-  encoding = getOption("encoding"))
+build_home(pkg = ".", path = "docs", depth = 0L, encoding = "UTF-8")
 }
 \arguments{
 \item{pkg}{Path to source package.}

--- a/man/build_site.Rd
+++ b/man/build_site.Rd
@@ -7,7 +7,7 @@
 \usage{
 build_site(pkg = ".", path = "docs", examples = TRUE,
   run_dont_run = FALSE, mathjax = TRUE, preview = interactive(),
-  seed = 1014)
+  seed = 1014, encoding = getOption("encoding"))
 
 init_site(pkg = ".", path = "docs")
 }
@@ -27,6 +27,8 @@ path.}
 
 \item{seed}{Seed used to initialize so that random examples are
 reproducible.}
+
+\item{encoding}{The encoding of the input files.}
 }
 \description{
 \code{build_site()} is a convenient wrapper around four functions:

--- a/man/build_site.Rd
+++ b/man/build_site.Rd
@@ -7,7 +7,7 @@
 \usage{
 build_site(pkg = ".", path = "docs", examples = TRUE,
   run_dont_run = FALSE, mathjax = TRUE, preview = interactive(),
-  seed = 1014, encoding = getOption("encoding"))
+  seed = 1014, encoding = "UTF-8")
 
 init_site(pkg = ".", path = "docs")
 }


### PR DESCRIPTION
Hi, I got this error to build a site for my package:

```r
pkgdown::build_site()
#> ...snip...
#> Updating README.md
#> Quitting from lines 71-74 (README.Rmd) 
#>  Error in parse(text = x, srcfile = src) : 
#>   invalid multibyte character in parser at line 3
```

The [README.Rmd in my package](https://github.com/yutannihilation/estatapi/blob/master/README.Rmd) contains non-ASCII characters and its encoding is UTF-8. This is fine with macOS and Linux, but I'm using Windows, where default encoding is not UTF-8. I have to pass `encoding = "UTF-8"` to `rmarkdown::render()` to knit UTF-8 files.

This PR adds `encoding` argument to fix this issue.