### PR TITLE
Support multiple given names

### DIFF
--- a/R/build-home-authors.R
+++ b/R/build-home-authors.R
@@ -71,11 +71,7 @@ build_authors <- function(pkg = ".", path = "docs", depth = 0L) {
 }
 
 author_name <- function(x, authors) {
-  if (is.null(x$family)) {
-    name <- x$given
-  } else {
-    name <- paste0(x$given, " ", x$family)
-  }
+  name <- format_author_name(x$given, x$family)
 
   if (!(name %in% names(authors)))
     return(name)
@@ -90,6 +86,16 @@ author_name <- function(x, authors) {
     name
   } else {
     paste0("<a href='", author$href, "'>", name, "</a>")
+  }
+}
+
+format_author_name <- function(given, family) {
+  given <- paste(given, collapse = " ")
+
+  if (is.null(family)) {
+    given
+  } else {
+    paste0(given, " ", family)
   }
 }
 


### PR DESCRIPTION
`given` can be a character vector, see [`?person`](https://www.rdocumentation.org/packages/utils/versions/3.3.1/topics/person).

@hadley: PTAL, can't build RSQLite docs without this.