### PR TITLE
Support exclude for reference/title

### DIFF
--- a/R/build-reference-index.R
+++ b/R/build-reference-index.R
@@ -8,7 +8,7 @@ data_reference_index <- function(pkg = ".", depth = 1L) {
 
   # Cross-reference complete list of topics vs. topics found in index page
   in_index <- meta %>%
-    purrr::map(~ has_topic(pkg$topics$alias, .$contents)) %>%
+    purrr::map(~ has_topic(pkg$topics$alias, .$contents, .$exclude)) %>%
     purrr::reduce(`+`)
 
   missing <- (in_index == 0) & !pkg$topics$internal
@@ -38,7 +38,7 @@ data_reference_index_section <- function(section, pkg, depth = 1L) {
   }
 
   # Match topics against any aliases
-  in_section <- has_topic(pkg$topics$alias, section$contents)
+  in_section <- has_topic(pkg$topics$alias, section$contents, section$exclude)
   section_topics <- pkg$topics[in_section, ]
   contents <- tibble::tibble(
     path = section_topics$file_out,
@@ -84,7 +84,12 @@ default_reference_index <- function(pkg = ".") {
 
 # Character vector of contents: xyz, starts_with("xyz")
 # List of aliases
-has_topic <- function(topics, matches) {
+has_topic <- function(topics, contains, exclude = NULL) {
+  match_topic(topics, contains %||% list()) &
+    !match_topic(topics, exclude %||% list())
+}
+
+match_topic <- function(topics, matches) {
   matchers <- purrr::map(matches, topic_matcher)
   topics %>%
     purrr::map_lgl(~ purrr::some(matchers, function(f) any(f(.))))

--- a/vignettes/pkgdown.Rmd
+++ b/vignettes/pkgdown.Rmd
@@ -67,6 +67,8 @@ reference:
 
 The `reference` should be an array of objects containing `title`, `desc` (description), and list of `contents`. Since common prefix and suffixes are often used for functional grouping, you can use the functions `starts_with()` and `ends_with()` to automatically include all functions with a common prefix or suffix. To match more complex patterns, use `matches()` with a regular expression.
 
+The objects in `reference` can also contain a list of `exclude`, which allow you to exclude unwanted topics included via `contents`.
+
 pkgdown will warn if you've forgotten to include any non-internal functions.
 
 ## Articles


### PR DESCRIPTION
Syntax example from RSQLite:

```yml
  - title: Connection methods
    contents:
    - matches("^[^,]+,SQLiteConnection")
    exclude:
    - query-dep
```

Do we need to be able to exclude internal functions?

```yml
  - title: Connection methods
    contents:
    - matches("^[^,]+,SQLiteConnection")
    exclude:
    - query-dep
    - is_internal()
```