### PR TITLE
Keep topics in order

### DIFF
--- a/R/build-reference-index.R
+++ b/R/build-reference-index.R
@@ -37,9 +37,14 @@ data_reference_index_section <- function(section, pkg, depth = 1L) {
     return(NULL)
   }
 
-  # Match topics against any aliases
-  in_section <- has_topic(pkg$topics$alias, section$contents)
-  section_topics <- pkg$topics[in_section, ]
+  # Match section topics (section$contents) against any aliases
+  section_topic_files <- topic_files(pkg$topics$alias, section$contents)
+
+  section_topic_rows <- section_topic_files %>%
+    purrr::map_int(function(topic_file) which(topic_file == pkg$topics$file_in))
+
+  section_topics <- pkg$topics[section_topic_rows, ]
+
   contents <- tibble::tibble(
     path = section_topics$file_out,
     aliases = section_topics$alias,
@@ -82,12 +87,30 @@ default_reference_index <- function(pkg = ".") {
   ))
 }
 
-# Character vector of contents: xyz, starts_with("xyz")
+# matches: Character vector of contents: xyz, starts_with("xyz")
 # List of aliases
 has_topic <- function(topics, matches) {
   matchers <- purrr::map(matches, topic_matcher)
   topics %>%
     purrr::map_lgl(~ purrr::some(matchers, function(f) any(f(.))))
+}
+
+topic_files <- function(topics, matches) {
+
+  # Returns the topic file name for a matcher function
+  find_topic_files <- function(matcher) {
+    topics %>%
+      purrr::keep(function(section_topic) any(purrr::map_lgl(section_topic, matcher))) %>%
+      names %>%
+      unlist
+  }
+
+  matches %>% 
+    purrr::map(topic_matcher) %>%
+    purrr::map(find_topic_files) %>%
+    unlist %>%
+    unique
+
 }
 
 # Takes text specification and converts it to a predicate function

--- a/R/build-reference-index.R
+++ b/R/build-reference-index.R
@@ -87,7 +87,7 @@ default_reference_index <- function(pkg = ".") {
   ))
 }
 
-# matches: Character vector of contents: xyz, starts_with("xyz")
+# matches: Character vector of contents e.g. xyz, starts_with("xyz")
 # List of aliases
 has_topic <- function(topics, matches) {
   matchers <- purrr::map(matches, topic_matcher)
@@ -95,6 +95,7 @@ has_topic <- function(topics, matches) {
     purrr::map_lgl(~ purrr::some(matchers, function(f) any(f(.))))
 }
 
+# Returns the topic file name(s) for a set of aliases (matches)
 topic_files <- function(topics, matches) {
 
   # Returns the topic file name(s) for a matcher function
@@ -110,7 +111,6 @@ topic_files <- function(topics, matches) {
     purrr::map(find_topic_files) %>%
     unlist %>%
     unique
-
 }
 
 # Takes text specification and converts it to a predicate function

--- a/R/build-reference-index.R
+++ b/R/build-reference-index.R
@@ -97,7 +97,7 @@ has_topic <- function(topics, matches) {
 
 topic_files <- function(topics, matches) {
 
-  # Returns the topic file name for a matcher function
+  # Returns the topic file name(s) for a matcher function
   find_topic_files <- function(matcher) {
     topics %>%
       purrr::keep(function(section_topic) any(purrr::map_lgl(section_topic, matcher))) %>%

--- a/docs/articles/pkgdown.html
+++ b/docs/articles/pkgdown.html
@@ -85,6 +85,7 @@
       <span class="kw">-</span> starts_with(<span class="st">"spark_write"</span>)
       <span class="kw">-</span> sdf-saveload</code></pre></div>
 <p>The <code>reference</code> should be an array of objects containing <code>title</code>, <code>desc</code> (description), and list of <code>contents</code>. Since common prefix and suffixes are often used for functional grouping, you can use the functions <code>starts_with()</code> and <code>ends_with()</code> to automatically include all functions with a common prefix or suffix. To match more complex patterns, use <code>matches()</code> with a regular expression.</p>
+<p>The objects in <code>reference</code> can also contain a list of <code>exclude</code>, which allow you to exclude unwanted topics included via <code>contents</code>.</p>
 <p>pkgdown will warn if you&rsquo;ve forgotten to include any non-internal functions.</p>
 </div>
 <div id="articles" class="section level2">

--- a/docs/reference/build_reference.html
+++ b/docs/reference/build_reference.html
@@ -97,7 +97,7 @@ below.</p>
       <dt>lazy</dt>
       <dd>If <code>TRUE</code>, only rebuild pages where the <code>.Rd</code>
 is more recent than the <code>.html</code>. This makes it much easier to
-rapidly protoype. It is set to <code>FALSE</code> by <code>pkgdown</code>.</dd>
+rapidly protoype. It is set to <code>FALSE</code> by <code><a href='build_site.html'>build_site</a></code>.</dd>
       <dt>examples</dt>
       <dd>Run examples?</dd>
       <dt>run_dont_run</dt>
@@ -163,10 +163,11 @@ retina display). Icons are matched to topics by aliases.</p>
 #&gt;  [91]  91  92  93  94  95  96  97  98  99 100</div><div class='input'>
 <span class='fu'>cat</span>(<span class='st'>"This some text!\n"</span>)</div><div class='output co'>#&gt; This some text!</div><div class='input'><span class='fu'>message</span>(<span class='st'>"This is a message!"</span>)</div><div class='output co'>#&gt; <span class='message'>This is a message!</span></div><div class='input'><span class='fu'>warning</span>(<span class='st'>"This is a warning!"</span>)</div><div class='output co'>#&gt; <span class='warning'>Warning: This is a warning!</span></div><div class='input'>
 <span class='co'>## Not run: ------------------------------------</span>
-<span class='co'># stop("This is an error!")</span>
+<span class='co'># stop("This is an error!", call. = FALSE)</span>
 <span class='co'>## ---------------------------------------------</span>
 
-<span class='co'># This code won't generally be run by CRAN</span>
+<span class='co'># This code won't generally be run by CRAN. But it</span>
+<span class='co'># will be run by testthat.</span>
 <span class='no'>b</span> <span class='kw'>&lt;-</span> <span class='fl'>10</span>
 <span class='no'>a</span> + <span class='no'>b</span></div><div class='output co'>#&gt;   [1]  11  12  13  14  15  16  17  18  19  20  21  22  23  24  25  26  27  28
 #&gt;  [19]  29  30  31  32  33  34  35  36  37  38  39  40  41  42  43  44  45  46

--- a/docs/reference/index.html
+++ b/docs/reference/index.html
@@ -111,14 +111,14 @@
       <p class="section-desc"></p>
 
       
-      <p><a href="render_page.html">Render page with template</a></p>
-      <ul>
-        <li><code><a href="render_page.html">render_page</a></code></li><li><code><a href="render_page.html">data_template</a></code></li>
-      </ul>
-      
       <p><a href="templates.html">Generate YAML templates</a></p>
       <ul>
         <li><code><a href="templates.html">template_navbar</a></code></li><li><code><a href="templates.html">template_reference</a></code></li><li><code><a href="templates.html">template_articles</a></code></li>
+      </ul>
+      
+      <p><a href="render_page.html">Render page with template</a></p>
+      <ul>
+        <li><code><a href="render_page.html">render_page</a></code></li><li><code><a href="render_page.html">data_template</a></code></li>
       </ul>
     
     </div>


### PR DESCRIPTION
Fixes #213 

Using this PR, `template` is now listed before `render_page` in docs/reference/index.html, i.e. topics are in the order that is specified in the YAML file. Everything else stays the same. The changes in docs/reference/build_reference.html are caused by a roxygen run before the last build_site(). The change in  docs/articles/pkgdown.html is caused by build_site(), updating the docs.