### PR TITLE
fix the render.r to enable  "template" section in _pkgdown.yml worked properly

### DIFF
--- a/R/render.r
+++ b/R/render.r
@@ -60,7 +60,7 @@ data_template <- function(pkg = ".", depth = 0L) {
 
   # Force inclusion so you can reliably refer to objects inside yaml
   # in the moustache templates
-  yaml <- pkg$meta$templates$params %||% list()
+  yaml <- pkg$meta$template$params %||% list()
   yaml$.present <- TRUE
 
   print_yaml(list(
@@ -85,7 +85,7 @@ template_path <- function(pkg = ".") {
   template <- pkg$meta[["template"]]
 
   if (!is.null(template$path)) {
-    path <- rel_path(pkg$path, template_path)
+    path <- rel_path(pkg$path, template$path)
 
     if (!file.exists(path))
       stop("Can not find template path '", path, "'", call. = FALSE)


### PR DESCRIPTION
1. fix #208: in line 88 : 
2. mod in line 63: making the "params" of template section in yaml config worked properly, e.g. parameter *bootswatch*
  
```
template:
    params:
      bootswatch: cerulean
```