### PR TITLE
Do not apply html escaping on function argument names

### DIFF
--- a/inst/templates/content-reference-topic.html
+++ b/inst/templates/content-reference-topic.html
@@ -18,7 +18,7 @@
     <h2 class="hasAnchor" id="arguments"><a class="anchor" href="#arguments"></a> Arguments</h2>
     <dl class="dl-horizontal">
     {{#arguments}}
-      <dt>{{name}}</dt>
+      <dt>{{{name}}}</dt>
       <dd>{{{description}}}</dd>
     {{/arguments}}
     </dl>


### PR DESCRIPTION
Fixes #215

A similar problem presumably occurs with the html entities inserted
for the dQuote and sQuote tags in R/rd-html.R. As they can occur on many
occasions, the fix needs to be different.