### PR TITLE
close #251: parse package names with alnum and dots

### DIFF
--- a/R/build-news.R
+++ b/R/build-news.R
@@ -121,7 +121,7 @@ data_news <- function(pkg = ".", depth = 1L) {
   anchors <- sections %>%
     xml2::xml_attr("id")
 
-  re <- regexec("^([[:alpha:]]+)\\s+((\\d+[.-]\\d+)(?:[.-]\\d+)*)", titles)
+  re <- regexec("^([[:alnum:],\\.]+)\\s+((\\d+[.-]\\d+)(?:[.-]\\d+)*)", titles)
   pieces <- regmatches(titles, re)
 
   # Only keep sections with unambiguous version


### PR DESCRIPTION
From [Writing R Extensions](https://cran.r-project.org/doc/manuals/r-release/R-exts.html#The-DESCRIPTION-file): 

> The mandatory ‘Package’ field gives the name of the package. This should contain only (ASCII) letters, numbers and dot [...]