### PR TITLE
Adds vignette caveat to articles' documentation

### DIFF
--- a/vignettes/pkgdown.Rmd
+++ b/vignettes/pkgdown.Rmd
@@ -77,7 +77,7 @@ pkgdown will warn if you've forgotten to include any non-internal functions.
 
 pkgdown will automatically build all `.Rmd` vignettes, including those in subdirectories, and render output to `articles/`. pkgdown will ignore the output format defined in the yaml header, and always use `html_fragment(toc = TRUE, toc_float = TRUE)`.
 
-If you want to include an article on the website, but not in the package (e.g. because it's large), you can either place it in a subdirectory of `vignettes/` or add to `.Rbuildignore`.  In the extreme case where you want to produce only articles but not vignettes, you can add the complete `vignettes/` directory to `.Rbuildignore`.
+If you want to include an article on the website, but not in the package (e.g. because it's large), you can either place it in a subdirectory of `vignettes/` or add to `.Rbuildignore`. As well, you must ensure that there is no `vignettes:` section in the article's yaml header. In the extreme case where you want to produce only articles but not vignettes, you can add the complete `vignettes/` directory to `.Rbuildignore`. 
 
 As with the function reference, articles will also get a default index, and it can be customised in a similar way (referring to file names rather than function names):
 

--- a/vignettes/pkgdown.Rmd
+++ b/vignettes/pkgdown.Rmd
@@ -77,7 +77,7 @@ pkgdown will warn if you've forgotten to include any non-internal functions.
 
 pkgdown will automatically build all `.Rmd` vignettes, including those in subdirectories, and render output to `articles/`. pkgdown will ignore the output format defined in the yaml header, and always use `html_fragment(toc = TRUE, toc_float = TRUE)`.
 
-If you want to include an article on the website, but not in the package (e.g. because it's large), you can either place it in a subdirectory of `vignettes/` or add to `.Rbuildignore`. As well, you must ensure that there is no `vignettes:` section in the article's yaml header. In the extreme case where you want to produce only articles but not vignettes, you can add the complete `vignettes/` directory to `.Rbuildignore`. 
+If you want to include an article on the website, but not in the package (e.g. because it's large), you can either place it in a subdirectory of `vignettes/` or add to `.Rbuildignore`. As well, you must ensure that there is no `vignettes:` section in the article's yaml header. In the extreme case where you want to produce only articles but not vignettes, you can add the complete `vignettes/` directory to `.Rbuildignore`.
 
 As with the function reference, articles will also get a default index, and it can be customised in a similar way (referring to file names rather than function names):
 


### PR DESCRIPTION
I included a "fixes #xxx" comment because the narrow issue of documenting this behavior has been addressed. You may wish to re-open to keep a reminder of the underlying behavior.

If I should open a different issue elsewhere, I remain at your service.