### PR TITLE
Remove space between anchor and img

### DIFF
--- a/R/util.r
+++ b/R/util.r
@@ -57,7 +57,8 @@ markdown <- function(path = NULL, ..., depth = 0L, index = NULL) {
   lines <- readLines(tmp, warn = FALSE)
   lines <- sub("<body>", "", lines, fixed = TRUE)
   lines <- sub("</body>", "", lines, fixed = TRUE)
-  paste(lines, collapse = "\n")
+  lines <- paste(lines, collapse = "\n")
+  gsub("</a></html>\n<img", "</a></html><img", lines, fixed=TRUE)
 }
 
 tweak_anchors <- function(html, only_contents = TRUE) {


### PR DESCRIPTION
Solving #284 produces another, let's say, unintended behaviour. When there is no `<img>` in the `<h1`, we have:

```
<h1 class="hasAnchor">
<a ... class="anchor"> </a>some text</h1>
```

But if there is an `<img>`, we have:

```
<h1 class="hasAnchor">
<a ... class="anchor"> </a>
<img ...>some text</h1>
```
And the rendering of this produces an ugly space before the image. To solve it, we should have:

```
<h1 class="hasAnchor">
<a ... class="anchor"> </a><img ...>some text</h1>
```

The thing is that [this function](https://github.com/hadley/pkgdown/blob/master/R/util.r#L89) puts the newline only when the first argument is a tag, not text. So there is not much that we can do about it, except for removing such a newline. This patch is a workaround (although not very elegant, I have to say).