### PR TITLE
Not apply html escaping on the content-reference-index title

### DIFF
--- a/inst/templates/content-reference-index.html
+++ b/inst/templates/content-reference-index.html
@@ -25,7 +25,7 @@
           <td>
             <p>{{#aliases}}<code><a href="{{path}}">{{.}}</a></code> {{/aliases}}</p>
           </td>
-          <td><p>{{title}}</p></td>
+          <td><p>{{{title}}}</p></td>
         </tr>{{/contents}}
       </tbody>{{/sections}}
       </table>


### PR DESCRIPTION
#297. By default [whisker](https://github.com/edwindj/whisker#note) applies `html` escaping on the generated text, and Ampersands (&)  will be escaped as \&amp; To prevent this use {{{variable}}} (triple) in stead of {{variable}}.