### PR TITLE
Changing arguments for available packages

### DIFF
--- a/R/build-home.R
+++ b/R/build-home.R
@@ -261,8 +261,7 @@ cran_mirror <- function() {
     cran
   }
 }
-on_cran <- function(pkg, cran = NULL) {
-  cran <- ifelse(is.null(cran), cran_mirror(), cran)
+on_cran <- function(pkg, cran = cran_mirror()) {
   pkgs <- utils::available.packages(
     type = "source",
     contriburl = paste0(cran, "/src/contrib"))

--- a/R/build-home.R
+++ b/R/build-home.R
@@ -264,7 +264,7 @@ cran_mirror <- function() {
 on_cran <- function(pkg) {
   pkgs <- utils::available.packages(
     type = "source",
-    contriburl = paste0(pkgdown:::cran_mirror(), "/src/contrib"))
+    contriburl = paste0(cran_mirror(), "/src/contrib"))
   pkg %in% rownames(pkgs)
 }
 

--- a/R/build-home.R
+++ b/R/build-home.R
@@ -264,10 +264,10 @@ cran_mirror <- function() {
 on_cran <- function(pkg) {
   pkgs <- utils::available.packages(
     type = "source",
-    repos = list(CRAN = cran_mirror())
-  )
+    contriburl = paste0(pkgdown:::cran_mirror(), "/src/contrib"))
   pkg %in% rownames(pkgs)
 }
+
 
 link_url <- function(text, href) {
   label <- gsub("(/+)", "\\1&#8203;", href)

--- a/R/build-home.R
+++ b/R/build-home.R
@@ -261,10 +261,11 @@ cran_mirror <- function() {
     cran
   }
 }
-on_cran <- function(pkg) {
+on_cran <- function(pkg, cran = NULL) {
+  cran <- ifelse(is.null(cran), cran_mirror(), cran)
   pkgs <- utils::available.packages(
     type = "source",
-    contriburl = paste0(cran_mirror(), "/src/contrib"))
+    contriburl = paste0(cran, "/src/contrib"))
   pkg %in% rownames(pkgs)
 }
 

--- a/tests/testthat/test-build_home.R
+++ b/tests/testthat/test-build_home.R
@@ -67,3 +67,30 @@ test_that("links to vignettes & figures tweaked", {
 
   expect_output_file(cat(as.character(html)), "home-links.html")
 })
+
+
+# cran --------------------------------------------------------------------
+
+
+test_that("package CRAN verification", {
+
+  #Package on CRAN, checking against default
+  expect_equal(on_cran("dplyr"), TRUE)
+  #Package on CRAN, checking against alternate mirror 1
+  expect_equal(on_cran("dplyr", "https://cran.stat.auckland.ac.nz"), TRUE)
+  #Package on CRAN, checking against alternate mirror 2
+  expect_equal(on_cran("dplyr", "https://cran.cnr.berkeley.edu"), TRUE)
+  #Package on CRAN, checking against alternate mirror 3
+  expect_equal(on_cran("dplyr", "https://cloud.r-project.org"), TRUE)
+
+  #Package not on CRAN, checking against default
+  expect_equal(on_cran("notarealpkg"), FALSE)
+  #Package not on CRAN, checking against alternate mirror 1
+  expect_equal(on_cran("notarealpkg", "https://cran.stat.auckland.ac.nz"), FALSE)
+  #Package not on CRAN, checking against alternate mirror 2
+  expect_equal(on_cran("notarealpkg", "https://cran.cnr.berkeley.edu"), FALSE)
+  #Package not on CRAN, checking against alternate mirror 3
+  expect_equal(on_cran("notarealpkg", "https://cloud.r-project.org"), FALSE)
+
+})
+

--- a/tests/testthat/test-build_home.R
+++ b/tests/testthat/test-build_home.R
@@ -74,23 +74,11 @@ test_that("links to vignettes & figures tweaked", {
 
 test_that("package CRAN verification", {
 
-  #Package on CRAN, checking against default
-  expect_equal(on_cran("dplyr"), TRUE)
-  #Package on CRAN, checking against alternate mirror 1
-  expect_equal(on_cran("dplyr", "https://cran.stat.auckland.ac.nz"), TRUE)
-  #Package on CRAN, checking against alternate mirror 2
-  expect_equal(on_cran("dplyr", "https://cran.cnr.berkeley.edu"), TRUE)
-  #Package on CRAN, checking against alternate mirror 3
-  expect_equal(on_cran("dplyr", "https://cloud.r-project.org"), TRUE)
+  expect_true(on_cran("dplyr"))
+  expect_true(on_cran("dplyr", "https://cloud.r-project.org"))
 
-  #Package not on CRAN, checking against default
-  expect_equal(on_cran("notarealpkg"), FALSE)
-  #Package not on CRAN, checking against alternate mirror 1
-  expect_equal(on_cran("notarealpkg", "https://cran.stat.auckland.ac.nz"), FALSE)
-  #Package not on CRAN, checking against alternate mirror 2
-  expect_equal(on_cran("notarealpkg", "https://cran.cnr.berkeley.edu"), FALSE)
-  #Package not on CRAN, checking against alternate mirror 3
-  expect_equal(on_cran("notarealpkg", "https://cloud.r-project.org"), FALSE)
+  expect_false(on_cran("notarealpkg"))
+  expect_false(on_cran("notarealpkg", "https://cloud.r-project.org"))
 
 })
 


### PR DESCRIPTION
Fixes #303 

Tested this fix with 3 different mirrors and they all worked: 

- cran <- as.list(getOption("source"))[["CRAN"]]
- cran <- "https://cran.usthb.dz/"
- cran <- "https://cran.cnr.berkeley.edu/"

Also tested it to build spark.rstudio.com and it  worked as well.