### PR TITLE
Make Magick an optional dependency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,7 +15,6 @@ Imports:
     digest,
     evaluate,
     highlight,
-    magick,
     magrittr,
     purrr,
     pkgload,
@@ -30,6 +29,7 @@ Imports:
 Suggests:
     devtools,
     knitr,
+    magick,
     testthat
 Remotes:
     r-pkgs/pkgload,

--- a/R/build-logo.R
+++ b/R/build-logo.R
@@ -6,6 +6,10 @@ build_logo <- function(pkg = ".", path = "docs/") {
   if (is.null(logo_path))
     return()
 
+  if (!requireNamespace("magick", quietly = TRUE)) {
+    message("Magick not avaliable, not creating favicon.ico")
+    return()
+  }
   message("Copying logo")
   file.copy(logo_path, file.path(path, "logo.png"))
 


### PR DESCRIPTION
Magick can be painful to get installed when it isn’t easy to get the imagemagick Magick++ library installed. Since it is only used for favicon.ico creation, I've made magick an optional dependency, allowing me to use the rest of the package. 

This was useful to me personally, but I figured I'd send a pull request in case it was useful to others as well. 

