### PR TITLE
Support other extensions for the NEWS file

### DIFF
--- a/R/build-news.R
+++ b/R/build-news.R
@@ -1,13 +1,14 @@
 #' Build news section
 #'
-#' Your \code{NEWS.md} is parsed in to sections based on your use of
-#' headings. Each minor version (i.e. the combination of first and second
-#' components) gets on one page, with all patch versions (i.e. the third
-#' component) on a single page. News items for development versions (by
-#' convention those versions with a fourth component) are displayed on an
-#' an "unreleased" page.
+#' The first file found between \code{NEWS.md}, \code{NEWS.Rd} and \code{NEWS}
+#' is parsed in to sections based on your use of headings. Each minor version
+#' (i.e. the combination of first and second components) gets on one page, with
+#' all patch versions (i.e. the third component) on a single page. News items
+#' for development versions (by convention those versions with a fourth
+#' component) are displayed on an an "unreleased" page.
 #'
-#' The \code{NEWS.md} file should be formatted somewhat like this:
+#' The \code{NEWS.md}, \code{NEWS.Rd} or \code{NEWS} file should be formatted
+#' somewhat like this:
 #'
 #' \preformatted{
 #' # pkgdown 0.1.0.9000
@@ -108,7 +109,7 @@ globalVariables(".")
 data_news <- function(pkg = ".", depth = 1L) {
   pkg <- as_pkgdown(pkg)
   html <- markdown(
-    file.path(pkg$path, "NEWS.md"),
+    file_news(pkg$path),
     "--section-divs",
     depth = depth,
     index = pkg$topics
@@ -150,8 +151,14 @@ data_news <- function(pkg = ".", depth = 1L) {
   news[is_version, , drop = FALSE]
 }
 
+file_news <- function(path = ".") {
+  find_first_existing(path,
+    c("NEWS.md", "NEWS.Rd", "NEWS")
+  )
+}
+
 has_news <- function(path = ".") {
-  file.exists(file.path(path, "NEWS.md"))
+  !is.null(file_news(path))
 }
 
 is_dev <- function(version) {

--- a/docs/articles/pkgdown.html
+++ b/docs/articles/pkgdown.html
@@ -136,7 +136,13 @@
 <div id="news" class="section level2">
 <h2 class="hasAnchor">
 <a href="#news" class="anchor"></a>News</h2>
-<p>If <code>NEWS.md</code> is present, it will be parsed into pieces broken up by second level headings. These will be rendered to <code>news/</code>, with one page per minor release (so that <code>2.2.0</code>, <code>2.2.1</code>, and <code>2.2.2</code> are all described on a single page).</p>
+<p>The news page will be automatically parsed from one of the following files:</p>
+<ol style="list-style-type: decimal">
+<li><code>NEWS.md</code></li>
+<li><code>NEWS.Rd</code></li>
+<li><code>NEWS</code></li>
+</ol>
+<p>The first file found will be parsed into pieces broken up by second level headings. These will be rendered to <code>news/</code>, with one page per minor release (so that <code>2.2.0</code>, <code>2.2.1</code>, and <code>2.2.2</code> are all described on a single page).</p>
 <p>If you want more detailed release notes (aimed at teaching people about the new features), you could put these in (e.g.) <code>vignettes/news</code> and customise the navbar.</p>
 </div>
 <div id="navbar2" class="section level2">

--- a/docs/reference/build_news.html
+++ b/docs/reference/build_news.html
@@ -80,12 +80,12 @@
     </div>
 
     
-    <p>Your <code>NEWS.md</code> is parsed in to sections based on your use of
-headings. Each minor version (i.e. the combination of first and second
-components) gets on one page, with all patch versions (i.e. the third
-component) on a single page. News items for development versions (by
-convention those versions with a fourth component) are displayed on an
-an "unreleased" page.</p>
+    <p>The first file found between <code>NEWS.md</code>, <code>NEWS.Rd</code> and <code>NEWS</code>
+is parsed in to sections based on your use of headings. Each minor version
+(i.e. the combination of first and second components) gets on one page, with
+all patch versions (i.e. the third component) on a single page. News items
+for development versions (by convention those versions with a fourth
+component) are displayed on an an "unreleased" page.</p>
     
 
     <pre class="usage"><span class='fu'>build_news</span>(<span class='kw'>pkg</span> <span class='kw'>=</span> <span class='st'>"."</span>, <span class='kw'>path</span> <span class='kw'>=</span> <span class='st'>"docs/news"</span>, <span class='kw'>one_page</span> <span class='kw'>=</span> <span class='fl'>TRUE</span>, <span class='kw'>depth</span> <span class='kw'>=</span> <span class='fl'>1L</span>)</pre>
@@ -118,7 +118,8 @@ to adjust relative links in the navbar.</p></td>
     
     <h2 class="hasAnchor" id="details"><a class="anchor" href="#details"></a>Details</h2>
 
-    <p>The <code>NEWS.md</code> file should be formatted somewhat like this:</p><pre>
+    <p>The <code>NEWS.md</code>, <code>NEWS.Rd</code> or <code>NEWS</code> file should be formatted
+somewhat like this:</p><pre>
 # pkgdown 0.1.0.9000
     ## Major changes
     - Fresh approach based on the staticdocs package. Site configuration now based on YAML files.

--- a/man/build_news.Rd
+++ b/man/build_news.Rd
@@ -21,15 +21,16 @@ If \code{FALSE}, writes one file per major version.}
 to adjust relative links in the navbar.}
 }
 \description{
-Your \code{NEWS.md} is parsed in to sections based on your use of
-headings. Each minor version (i.e. the combination of first and second
-components) gets on one page, with all patch versions (i.e. the third
-component) on a single page. News items for development versions (by
-convention those versions with a fourth component) are displayed on an
-an "unreleased" page.
+The first file found between \code{NEWS.md}, \code{NEWS.Rd} and \code{NEWS}
+is parsed in to sections based on your use of headings. Each minor version
+(i.e. the combination of first and second components) gets on one page, with
+all patch versions (i.e. the third component) on a single page. News items
+for development versions (by convention those versions with a fourth
+component) are displayed on an an "unreleased" page.
 }
 \details{
-The \code{NEWS.md} file should be formatted somewhat like this:
+The \code{NEWS.md}, \code{NEWS.Rd} or \code{NEWS} file should be formatted
+somewhat like this:
 
 \preformatted{
 # pkgdown 0.1.0.9000

--- a/vignettes/pkgdown.Rmd
+++ b/vignettes/pkgdown.Rmd
@@ -96,7 +96,13 @@ articles:
 
 ## News
 
-If `NEWS.md` is present, it will be parsed into pieces broken up by second level headings. These will be rendered to `news/`, with one page per minor release (so that `2.2.0`, `2.2.1`, and `2.2.2` are all described on a single page).
+The news page will be automatically parsed from one of the following files:
+
+1. `NEWS.md`
+1. `NEWS.Rd`
+1. `NEWS`
+
+The first file found will be parsed into pieces broken up by second level headings. These will be rendered to `news/`, with one page per minor release (so that `2.2.0`, `2.2.1`, and `2.2.2` are all described on a single page).
 
 If you want more detailed release notes (aimed at teaching people about the new features), you could put these in (e.g.) `vignettes/news` and customise the navbar.
 


### PR DESCRIPTION
Currently, only `NEWS.md` files are parsed to generate news. However, `NEWS` and `NEWS.Rd` are also used (for instance, as according to [Bioconductor guidelines](http://master.bioconductor.org/packages/devel/bioc/vignettes/BiocCheck/inst/doc/BiocCheck.html#news-checks)) and should be supported.