### PR TITLE
Add simplify_aliases to build_reference_index

### DIFF
--- a/R/build-reference.R
+++ b/R/build-reference.R
@@ -57,8 +57,8 @@
 #' @param seed Seed used to initialize so that random examples are
 #'   reproducible.
 #' @param simplify_aliases If \code{TRUE}, the aliases shown in reference index
-#' will be simplified to be only the method names, e.g. S3 method f1.data.frame
-#' will be shown as f1.
+#' will be simplified to be only the method names, e.g. S3 method `func.data.frame`
+#' will be shown as `func`.
 #' @export
 #' @examples
 #' # This example illustrates some important output types

--- a/R/build-reference.R
+++ b/R/build-reference.R
@@ -56,6 +56,9 @@
 #' @param mathjax Use mathjax to render math symbols?
 #' @param seed Seed used to initialize so that random examples are
 #'   reproducible.
+#' @param simplify_aliases If \code{TRUE}, the aliases shown in reference index
+#' will be simplified to be only the method names, e.g. S3 method f1.data.frame
+#' will be shown as f1.
 #' @export
 #' @examples
 #' # This example illustrates some important output types
@@ -90,7 +93,8 @@ build_reference <- function(pkg = ".",
                             mathjax = TRUE,
                             seed = 1014,
                             path = "docs/reference",
-                            depth = 1L
+                            depth = 1L,
+                            simplify_aliases = TRUE
                             ) {
   old <- set_pkgdown_env("true")
   on.exit(set_pkgdown_env(old))
@@ -113,7 +117,7 @@ build_reference <- function(pkg = ".",
     copy_dir(figures_path, out_path)
   }
 
-  build_reference_index(pkg, path = path, depth = depth)
+  build_reference_index(pkg, path = path, depth = depth, simplify_aliases = simplify_aliases)
 
   if (examples) {
     devtools::load_all(pkg$path)
@@ -135,7 +139,7 @@ build_reference <- function(pkg = ".",
 
 #' @export
 #' @rdname build_reference
-build_reference_index <- function(pkg = ".", path = "docs/reference", depth = 1L) {
+build_reference_index <- function(pkg = ".", path = "docs/reference", depth = 1L, simplify_aliases = TRUE) {
   pkg <- as_pkgdown(pkg)
   path <- rel_path(path, pkg$path)
 
@@ -148,7 +152,7 @@ build_reference_index <- function(pkg = ".", path = "docs/reference", depth = 1L
 
   render_page(
     pkg, "reference-index",
-    data = data_reference_index(pkg, depth = depth),
+    data = data_reference_index(pkg, depth = depth, simplify_aliases = simplify_aliases),
     path = out_path(path, "index.html"),
     depth = depth
   )

--- a/docs/articles/index.html
+++ b/docs/articles/index.html
@@ -74,7 +74,7 @@
       </header>
 
       <div class="page-header">
-  <h1>Vignette reference <small>version&nbsp;0.1.0.9000</small></h1>
+  <h1>Articles <small>version&nbsp;0.1.0.9000</small></h1>
 </div>
 
 <div class="row">

--- a/docs/articles/pkgdown.html
+++ b/docs/articles/pkgdown.html
@@ -95,7 +95,7 @@
 <a href="#reference" class="anchor"></a>Reference</h2>
 <p>The function reference generates one page for each <code>.Rd</code> file in <code>man/</code>, placing the results in <code>reference/</code>. This is mostly a straightforward translation of Rd to HTML, along with evaluating the examples, and auto-linking function names to their documentation.</p>
 <p>pkgdown will also generate an overall index, which by default, is just an alphabetically ordered list of functions. However, the index is better with human curation because functions can be grouped by function and described en masse. To override the defaults, provide a <code>reference</code> key in <code>_pkgdown.yml</code>:</p>
-<pre class="sourceCode yaml"><code class="sourceCode yaml"><span class="fu">reference:</span>
+<div class="sourceCode"><pre class="sourceCode yaml"><code class="sourceCode yaml"><span class="fu">reference:</span>
   <span class="kw">-</span> <span class="fu">title:</span> <span class="st">"Connecting to Spark"</span>
     <span class="fu">desc:</span> &gt;
       Functions for installing Spark components and managing
@@ -111,7 +111,7 @@
     <span class="fu">contents:</span>
       <span class="kw">-</span> starts_with(<span class="st">"spark_read"</span>)
       <span class="kw">-</span> starts_with(<span class="st">"spark_write"</span>)
-      <span class="kw">-</span> sdf-saveload</code></pre>
+      <span class="kw">-</span> sdf-saveload</code></pre></div>
 <p>The <code>reference</code> should be an array of objects containing <code>title</code>, <code>desc</code> (description), and list of <code>contents</code>. Since common prefix and suffixes are often used for functional grouping, you can use the functions <code>starts_with()</code> and <code>ends_with()</code> to automatically include all functions with a common prefix or suffix. To match more complex patterns, use <code>matches()</code> with a regular expression.</p>
 <p>The objects in <code>reference</code> can also contain a list of <code>exclude</code>, which allow you to exclude unwanted topics included via <code>contents</code>.</p>
 <p>pkgdown will warn if you’ve forgotten to include any non-internal functions.</p>
@@ -122,7 +122,7 @@
 <p>pkgdown will automatically build all <code>.Rmd</code> vignettes, including those in subdirectories, and render output to <code>articles/</code>. pkgdown will ignore the output format defined in the yaml header, and always use <code>html_fragment(toc = TRUE, toc_float = TRUE)</code>.</p>
 <p>If you want to include an article on the website, but not in the package (e.g. because it’s large), you can either place it in a subdirectory of <code>vignettes/</code> or add to <code>.Rbuildignore</code>. As well, you must ensure that there is no <code>vignettes:</code> section in the article’s yaml header. In the extreme case where you want to produce only articles but not vignettes, you can add the complete <code>vignettes/</code> directory to <code>.Rbuildignore</code>.</p>
 <p>As with the function reference, articles will also get a default index, and it can be customised in a similar way (referring to file names rather than function names):</p>
-<pre class="sourceCode yaml"><code class="sourceCode yaml"><span class="fu">articles:</span>
+<div class="sourceCode"><pre class="sourceCode yaml"><code class="sourceCode yaml"><span class="fu">articles:</span>
   <span class="kw">-</span> <span class="fu">title:</span> <span class="st">"Extend shiny"</span>
     <span class="fu">desc:</span> &gt;
       These packages provide advanced features that can enhance your Shiny 
@@ -131,7 +131,7 @@
     <span class="kw">-</span> shinydashboard
     <span class="kw">-</span> shinythemes
     <span class="kw">-</span> shinyjs
-    <span class="kw">-</span> htmlwidgets</code></pre>
+    <span class="kw">-</span> htmlwidgets</code></pre></div>
 </div>
 <div id="news" class="section level2">
 <h2 class="hasAnchor">
@@ -149,7 +149,7 @@
 <li><p>Link to other, off-site, resources.</p></li>
 </ul>
 <p>The navbar has a similar structure to the <a href="http://rmarkdown.rstudio.com/rmarkdown_websites.html#site_navigation">R Markdown website navbar</a>. To customise, use the <code>navbar</code> field:</p>
-<pre class="sourceCode yaml"><code class="sourceCode yaml"><span class="fu">navbar:</span>
+<div class="sourceCode"><pre class="sourceCode yaml"><code class="sourceCode yaml"><span class="fu">navbar:</span>
   <span class="fu">title:</span> <span class="st">"sparklyr"</span>
   <span class="fu">type:</span> inverse
   <span class="fu">left:</span>
@@ -167,7 +167,7 @@
       <span class="fu">href:</span> <span class="st">"reference/"</span>
   <span class="fu">right:</span>
     <span class="kw">-</span> <span class="fu">icon:</span> fa-github
-      <span class="fu">href:</span> https://github.com/rstudio/sparklyr</code></pre>
+      <span class="fu">href:</span> https://github.com/rstudio/sparklyr</code></pre></div>
 </div>
 </div>
   </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -68,14 +68,14 @@
 <h2 class="hasAnchor">
 <a href="#installation" class="anchor"></a>Installation</h2>
 <p>pkgdown is not currently available from CRAN, but you can install the development version from github with:</p>
-<pre class="sourceCode r"><code class="sourceCode r"><span class="co"># install.packages("devtools")</span>
-devtools::<span class="kw">install_github</span>(<span class="st">"hadley/pkgdown"</span>)</code></pre>
+<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="co"># install.packages("devtools")</span>
+devtools::<span class="kw">install_github</span>(<span class="st">"hadley/pkgdown"</span>)</code></pre></div>
 </div>
 <div id="usage" class="section level2">
 <h2 class="hasAnchor">
 <a href="#usage" class="anchor"></a>Usage</h2>
 <p>Run pkgdown from the package directory each time you release your package:</p>
-<pre class="sourceCode r"><code class="sourceCode r">pkgdown::<span class="kw"><a href="reference/build_site.html">build_site</a></span>()</code></pre>
+<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r">pkgdown::<span class="kw"><a href="reference/build_site.html">build_site</a></span>()</code></pre></div>
 <p>This will generate a <code>docs/</code> directory. The home page will be generated from your package’s <code>README.md</code>, and a function reference will be generated from the documentation in the <code>man/</code> directory. If you are using GitHub, the easiest way to make this your package website is to check into git, then go settings for your repo and make sure that the <strong>GitHub pages</strong> source is set to “master branch /docs folder”.</p>
 <p>The package also includes an RStudio add-in which you can bind to a keyboard shortcut. I recommend <code>Cmd + Shift + W</code>: it uses Cmd + Shift, like all other package development worksheets, it replaces a rarely used command (close all tabs), and the W is mnemonic for website.</p>
 </div>

--- a/docs/reference/build_reference.html
+++ b/docs/reference/build_reference.html
@@ -88,9 +88,10 @@ below.</p>
 
     <pre class="usage"><span class='fu'>build_reference</span>(<span class='kw'>pkg</span> <span class='kw'>=</span> <span class='st'>"."</span>, <span class='kw'>lazy</span> <span class='kw'>=</span> <span class='fl'>TRUE</span>, <span class='kw'>examples</span> <span class='kw'>=</span> <span class='fl'>TRUE</span>,
   <span class='kw'>run_dont_run</span> <span class='kw'>=</span> <span class='fl'>FALSE</span>, <span class='kw'>mathjax</span> <span class='kw'>=</span> <span class='fl'>TRUE</span>, <span class='kw'>seed</span> <span class='kw'>=</span> <span class='fl'>1014</span>,
-  <span class='kw'>path</span> <span class='kw'>=</span> <span class='st'>"docs/reference"</span>, <span class='kw'>depth</span> <span class='kw'>=</span> <span class='fl'>1L</span>)
+  <span class='kw'>path</span> <span class='kw'>=</span> <span class='st'>"docs/reference"</span>, <span class='kw'>depth</span> <span class='kw'>=</span> <span class='fl'>1L</span>, <span class='kw'>simplify_aliases</span> <span class='kw'>=</span> <span class='fl'>TRUE</span>)
 
-<span class='fu'>build_reference_index</span>(<span class='kw'>pkg</span> <span class='kw'>=</span> <span class='st'>"."</span>, <span class='kw'>path</span> <span class='kw'>=</span> <span class='st'>"docs/reference"</span>, <span class='kw'>depth</span> <span class='kw'>=</span> <span class='fl'>1L</span>)</pre>
+<span class='fu'>build_reference_index</span>(<span class='kw'>pkg</span> <span class='kw'>=</span> <span class='st'>"."</span>, <span class='kw'>path</span> <span class='kw'>=</span> <span class='st'>"docs/reference"</span>, <span class='kw'>depth</span> <span class='kw'>=</span> <span class='fl'>1L</span>,
+  <span class='kw'>simplify_aliases</span> <span class='kw'>=</span> <span class='fl'>TRUE</span>)</pre>
     
     <h2 class="hasAnchor" id="arguments"><a class="anchor" href="#arguments"></a> Arguments</h2>
     <table class="ref-arguments">
@@ -133,6 +134,12 @@ reproducible.</p></td>
       <th>depth</th>
       <td><p>Depth of path relative to root of documentation.  Used
 to adjust relative links in the navbar.</p></td>
+    </tr>
+    <tr>
+      <th>simplify_aliases</th>
+      <td><p>If <code>TRUE</code>, the aliases shown in reference index
+will be simplified to be only the method names, e.g. S3 method `func.data.frame`
+will be shown as `func`.</p></td>
     </tr>
     </table>
     

--- a/man/build_reference.Rd
+++ b/man/build_reference.Rd
@@ -37,8 +37,8 @@ reproducible.}
 to adjust relative links in the navbar.}
 
 \item{simplify_aliases}{If \code{TRUE}, the aliases shown in reference index
-will be simplified to be only the method names, e.g. S3 method f1.data.frame
-will be shown as f1.}
+will be simplified to be only the method names, e.g. S3 method `func.data.frame`
+will be shown as `func`.}
 }
 \description{
 By default, pkgdown will generate an index that simply lists all

--- a/man/build_reference.Rd
+++ b/man/build_reference.Rd
@@ -7,9 +7,10 @@
 \usage{
 build_reference(pkg = ".", lazy = TRUE, examples = TRUE,
   run_dont_run = FALSE, mathjax = TRUE, seed = 1014,
-  path = "docs/reference", depth = 1L)
+  path = "docs/reference", depth = 1L, simplify_aliases = TRUE)
 
-build_reference_index(pkg = ".", path = "docs/reference", depth = 1L)
+build_reference_index(pkg = ".", path = "docs/reference", depth = 1L,
+  simplify_aliases = TRUE)
 }
 \arguments{
 \item{pkg}{Path to source package. If R working directory is not
@@ -34,6 +35,10 @@ reproducible.}
 
 \item{depth}{Depth of path relative to root of documentation.  Used
 to adjust relative links in the navbar.}
+
+\item{simplify_aliases}{If \code{TRUE}, the aliases shown in reference index
+will be simplified to be only the method names, e.g. S3 method f1.data.frame
+will be shown as f1.}
 }
 \description{
 By default, pkgdown will generate an index that simply lists all


### PR DESCRIPTION
This allows users to display the full method name, especially for S3 methods. 

For example, if a package has 3 s3 methods, namely, `f1.data.frame(), f1.matrix(), f1.list()`. The default behavior will display only the method names in reference index page. It is better to display the full names in this case.