### PR TITLE
Set img max-width to 100%

### DIFF
--- a/inst/assets/pkgdown.css
+++ b/inst/assets/pkgdown.css
@@ -34,6 +34,10 @@ img.icon {
   float: right;
 }
 
+img {
+  max-width: 100%;
+}
+
 /* Section anchors ---------------------------------*/
 
 a.anchor {


### PR DESCRIPTION
Avoids images to overflow in the floating table of content

Before

![2017-05-26-175746_766x533_scrot](https://cloud.githubusercontent.com/assets/384198/26504664/70fdc5f4-423d-11e7-8366-0e9fefb0a68b.png)

After

![2017-05-26-175811_741x552_scrot](https://cloud.githubusercontent.com/assets/384198/26504694/89dc9a32-423d-11e7-826d-9a98bc1c94d1.png)

