### PR TITLE
Restore dummy objects in reference index; fixes #373

### DIFF
--- a/R/build-reference-index.R
+++ b/R/build-reference-index.R
@@ -48,7 +48,11 @@ data_reference_index_section <- function(section, pkg, depth = 1L) {
 
   contents <- tibble::tibble(
     path = section_topics$file_out,
-    aliases = purrr::map2(section_topics$funs, section_topics$name, ~ .x %||% .y),
+    aliases = purrr::map2(
+      section_topics$funs,
+      section_topics$name,
+      ~ if (length(.x) > 0) .x else .y
+    ),
     title = section_topics$title,
     icon = find_icons(section_topics$alias, file.path(pkg$path, "icons"))
   )


### PR DESCRIPTION
Fixes Overzealous pruning of topics #373

These issues might also be related?
  * Missing documentation when using dummy function to document s4 methods #395
  * Certain functions don't appear in index #374
  * Missing links to items in reference index #369

There's a problem with different definitions of `%||%`.

The rlang definition is `if (is_null(x)) y else x` but the previous "in-house" definition was `if (length(.x) > 0) .x else .y)`.

This line requires the length-based logic and it's where the link text is going missing, because right now we always take `section_topics$funs`:

https://github.com/hadley/pkgdown/blob/e2d1b6f662cf5c931522c125da4c4fafad972165/R/build-reference-index.R#L51

Whereas these lines require the null-based logic:

https://github.com/hadley/pkgdown/blob/081639735104a03c01527f568a99f0ef7351433d/R/link-context.R#L40-L41

The switch happened in 95c624e343f7b24765fc8e4b71fd69e8bd4f2222.

I assume you want to use `rlang::%||%`? I haven't looked to see if there are already tests for `data_reference_index_section()` that I should add to.