### PR TITLE
make vignette builder honor .Rbuildignore; fix vignette titles for missing YAML

### DIFF
--- a/R/package.r
+++ b/R/package.r
@@ -137,11 +137,13 @@ is_internal <- function(x) {
 
 package_vignettes <- function(path = ".") {
   # check for build exclusions
+  exclude <- NULL
   if (file.exists(file.path(".", ".Rbuildignore"))) {
     buildignore <- readLines(file.path(".", ".Rbuildignore"))
-    exclude <- paste0(buildignore, collapse = "|")
-  } else {
-    exclude <- NULL
+    buildignore <- buildignore[nchar(buildignore) > 0]
+    if (length(buildignore) > 0) {
+      exclude <- paste(buildignore, collapse = "|")
+    }
   }
 
   # find all non-excluded vignette directories


### PR DESCRIPTION
I have a weird setup in my package with an Rmd file in a subdirectory of `vignettes` that is ignored by `.Rbuildignore`. Currently, pkgdown tries to turn that Rmd file into an article. The first part of this patch addresses that issue.

The second part fixes the case where there is no title in the YAML but the file has a title in `%\VignetteIndexEntry`.

(I won't be offended if you reject some or all of this patch as it doesn't adhere to the coding style of the rest of `pkgdown`. I needed these fixes for my package but most users probably won't.)