### PR TITLE
make rel_path() work on Windows

### DIFF
--- a/R/util.r
+++ b/R/util.r
@@ -164,7 +164,15 @@ rel_path <- function(path, base = ".") {
     if (base != ".") {
       path <- file.path(base, path)
     }
-    normalizePath(path, mustWork = FALSE)
+    # normalizePath() on Windows expands to absolute paths,
+    # so strip normalized base from normalized path
+    if (Sys.info()["sysname"] == "Windows") {
+      base_full <- normalizePath(".", mustWork = FALSE, winslash = "/")
+      path_full <- normalizePath(path, mustWork = FALSE, winslash = "/")
+      gsub(paste0(base_full, "/"), "", path_full)
+    } else {
+      normalizePath(path, mustWork = FALSE, winslash = "/")
+    }
   }
 }
 

--- a/R/util.r
+++ b/R/util.r
@@ -171,7 +171,7 @@ rel_path <- function(path, base = ".", windows = on_windows()) {
     if (windows) {
       parent_full <- normalizePath(".", mustWork = FALSE, winslash = "/")
       path_full <- normalizePath(path, mustWork = FALSE, winslash = "/")
-      gsub(paste0(parent_full, "/"), "", path_full)
+      gsub(paste0(parent_full, "/"), "", path_full, fixed = TRUE)
     } else {
       normalizePath(path, mustWork = FALSE)
     }

--- a/R/util.r
+++ b/R/util.r
@@ -167,9 +167,9 @@ rel_path <- function(path, base = ".") {
     # normalizePath() on Windows expands to absolute paths,
     # so strip normalized base from normalized path
     if (Sys.info()["sysname"] == "Windows") {
-      base_full <- normalizePath(".", mustWork = FALSE, winslash = "/")
+      parent_full <- normalizePath(".", mustWork = FALSE, winslash = "/")
       path_full <- normalizePath(path, mustWork = FALSE, winslash = "/")
-      gsub(paste0(base_full, "/"), "", path_full)
+      gsub(paste0(parent_full, "/"), "", path_full)
     } else {
       normalizePath(path, mustWork = FALSE)
     }

--- a/R/util.r
+++ b/R/util.r
@@ -171,7 +171,7 @@ rel_path <- function(path, base = ".") {
       path_full <- normalizePath(path, mustWork = FALSE, winslash = "/")
       gsub(paste0(base_full, "/"), "", path_full)
     } else {
-      normalizePath(path, mustWork = FALSE, winslash = "/")
+      normalizePath(path, mustWork = FALSE)
     }
   }
 }

--- a/R/util.r
+++ b/R/util.r
@@ -153,11 +153,13 @@ find_first_existing <- function(path, ...) {
 #'
 #' @param path Relative path
 #' @param base Base path
+#' @param windows Whether the operating system is Windows. Default value is to
+#'   check the user's system information.
 #' @export
 #' @examples
 #' rel_path("a/b", base = "here")
 #' rel_path("/a/b", base = "here")
-rel_path <- function(path, base = ".") {
+rel_path <- function(path, base = ".", windows = on_windows()) {
   if (is_absolute_path(path)) {
     path
   } else {
@@ -166,7 +168,7 @@ rel_path <- function(path, base = ".") {
     }
     # normalizePath() on Windows expands to absolute paths,
     # so strip normalized base from normalized path
-    if (Sys.info()["sysname"] == "Windows") {
+    if (windows) {
       parent_full <- normalizePath(".", mustWork = FALSE, winslash = "/")
       path_full <- normalizePath(path, mustWork = FALSE, winslash = "/")
       gsub(paste0(parent_full, "/"), "", path_full)
@@ -174,6 +176,10 @@ rel_path <- function(path, base = ".") {
       normalizePath(path, mustWork = FALSE)
     }
   }
+}
+
+on_windows <- function() {
+  Sys.info()["sysname"] == "Windows"
 }
 
 is_absolute_path <- function(path) {

--- a/man/rel_path.Rd
+++ b/man/rel_path.Rd
@@ -4,12 +4,15 @@
 \alias{rel_path}
 \title{Compute relative path}
 \usage{
-rel_path(path, base = ".")
+rel_path(path, base = ".", windows = on_windows())
 }
 \arguments{
 \item{path}{Relative path}
 
 \item{base}{Base path}
+
+\item{windows}{Whether the operating system is Windows. Default value is to
+check the user's system information.}
 }
 \description{
 Compute relative path

--- a/tests/testthat/test-util.R
+++ b/tests/testthat/test-util.R
@@ -1,17 +1,27 @@
 context("util")
 
 test_that("rel_path() handles an absolute path", {
-  expect_equal(rel_path("\\drive\folder"), "\\drive\folder")
-  expect_equal(rel_path("/folder"), "/folder")
-  expect_equal(rel_path("C:\\folder"), "C:\\folder")
-  expect_equal(rel_path("C:/folder"), "C:/folder")
+  expect_equal(rel_path("\\drive\folder"), "\\drive\folder", windows = FALSE)
+  expect_equal(rel_path("\\drive\folder"), "\\drive\folder", windows = TRUE)
+
+  expect_equal(rel_path("/folder"), "/folder", windows = FALSE)
+  expect_equal(rel_path("/folder"), "/folder", windows = TRUE)
+
+  expect_equal(rel_path("C:\\folder"), "C:\\folder", windows = FALSE)
+  expect_equal(rel_path("C:\\folder"), "C:\\folder", windows = TRUE)
+
+  expect_equal(rel_path("C:/folder"), "C:/folder", windows = FALSE)
+  expect_equal(rel_path("C:/folder"), "C:/folder", windows = TRUE)
 })
 
 test_that("rel_path() returns a relative path (#409)", {
-  expect_equal(rel_path("a/b", "here"), "here/a/b")
-  expect_equal(rel_path("a/b", "."), "a/b")
-
-  # The path here is absolute so nothing happens
-  expect_equal(rel_path("/a/b", "here"), "/a/b")
-  expect_equal(rel_path("/a/b", "."), "/a/b")
+  skip_on_os("windows")
+  expect_equal(rel_path("a/b", "here", windows = FALSE), "here/a/b")
+  expect_equal(rel_path("a/b", ".", windows = FALSE), "a/b")
 })
+
+test_that("rel_path() for Windows compares strings to find path (#409)", {
+  expect_equal(rel_path("a/b", "here", windows = TRUE), "here/a/b")
+  expect_equal(rel_path("a/b", ".", windows = TRUE), "a/b")
+})
+

--- a/tests/testthat/test-util.R
+++ b/tests/testthat/test-util.R
@@ -1,0 +1,17 @@
+context("util")
+
+test_that("rel_path() handles an absolute path", {
+  expect_equal(rel_path("\\drive\folder"), "\\drive\folder")
+  expect_equal(rel_path("/folder"), "/folder")
+  expect_equal(rel_path("C:\\folder"), "C:\\folder")
+  expect_equal(rel_path("C:/folder"), "C:/folder")
+})
+
+test_that("rel_path() returns a relative path (#409)", {
+  expect_equal(rel_path("a/b", "here"), "here/a/b")
+  expect_equal(rel_path("a/b", "."), "a/b")
+
+  # The path here is absolute so nothing happens
+  expect_equal(rel_path("/a/b", "here"), "/a/b")
+  expect_equal(rel_path("/a/b", "."), "/a/b")
+})


### PR DESCRIPTION
Closes #409.

Also related to #307.

`normalizePath()` documentation says:

  > On Windows it converts relative paths to absolute paths, converts short names for path elements to long names and ensures the separator is that specified by winslash. It will match paths case-insensitively and return the canonical case. UTF-8-encoded paths not valid in the current locale can be used.

So that's why `rel_path()` didn't work on Windows.

To fix this, I first normalize the path directory and the current directory. The difference between the two strings is the relative path, so I use string-replacement to extract it out. 

This function below illustrates what happens inside the function on Windows.

```r
windows_rel_path_demo <- function(path, base) {
  if (is_absolute_path(path)) {
    path
  } else {
    if (base != ".") {
      path <- file.path(base, path)
    }
    # normalizePath() on Windows expands to absolute paths,
    # so strip normalized base from normalized path
    if (Sys.info()["sysname"] == "Windows") {
      parent_full <- normalizePath(".", mustWork = FALSE, winslash = "/")
      path_full <- normalizePath(path, mustWork = FALSE, winslash = "/")
      diff <- gsub(paste0(parent_full, "/"), "", path_full)
      list(
        base = base,
        path = path,
        parent_full = parent_full,
        path_full = path_full,
        diff = diff
      )
    } else {
      list()
    }
  }
}

is_absolute_path <- function(path) {
  grepl("^(/|[A-Za-z]:|\\\\|~)", path)
}

str(windows_rel_path_demo("docs", "."))
#> List of 5
#>  $ base       : chr "."
#>  $ path       : chr "docs"
#>  $ parent_full: chr "C:/Users/mahr/Desktop/GitRepos/pkgdown"
#>  $ path_full  : chr "C:/Users/mahr/Desktop/GitRepos/pkgdown/docs"
#>  $ diff       : chr "docs"
str(windows_rel_path_demo("site", "inst"))
#> List of 5
#>  $ base       : chr "inst"
#>  $ path       : chr "inst/site"
#>  $ parent_full: chr "C:/Users/mahr/Desktop/GitRepos/pkgdown"
#>  $ path_full  : chr "C:/Users/mahr/Desktop/GitRepos/pkgdown/inst/site"
#>  $ diff       : chr "inst/site"
```