### PR TITLE
Capture repo URL and not site URL when creating github link (fixes #412)

### DIFF
--- a/R/build-home.R
+++ b/R/build-home.R
@@ -195,7 +195,7 @@ data_link_github <- function(pkg = ".") {
     strsplit(",\\s+") %>%
     `[[`(1)
 
-  github <- grepl("github", urls)
+  github <- grepl("github\\.com", urls)
 
   if (!any(github))
     return(character())


### PR DESCRIPTION
...so now we filter out site URL in `urls` vector (e.g., filter out "http://hadley.github.io/pkgdown/").