### PR TITLE
admit .rmd extension for vignettes

### DIFF
--- a/R/link-article-index.R
+++ b/R/link-article-index.R
@@ -16,11 +16,11 @@ article_index_local <- function(package, path = find.package(package)) {
 
   vig_path <- dir(
     file.path(path, "vignettes"),
-    pattern = "\\.Rmd$",
+    pattern = "\\.[rR]md$",
     recursive = TRUE
   )
-  out_path <- gsub("\\.Rmd$", ".html", vig_path)
-  vig_name <- gsub("\\.Rmd$", "", basename(vig_path))
+  out_path <- gsub("\\.[rR]md$", ".html", vig_path)
+  vig_name <- gsub("\\.[rR]md$", "", basename(vig_path))
 
   set_names(out_path, vig_name)
 }

--- a/R/package.r
+++ b/R/package.r
@@ -138,7 +138,7 @@ is_internal <- function(x) {
 package_vignettes <- function(path = ".") {
   vig_path <- dir(
     file.path(path, "vignettes"),
-    pattern = "\\.Rmd$",
+    pattern = "\\.[rR]md$",
     recursive = TRUE
   )
 
@@ -148,7 +148,7 @@ package_vignettes <- function(path = ".") {
 
   tibble::tibble(
     file_in = vig_path,
-    file_out = gsub("\\.Rmd$", "\\.html", vig_path),
+    file_out = gsub("\\.[rR]md$", "\\.html", vig_path),
     name = tools::file_path_sans_ext(basename(vig_path)),
     path = dirname(vig_path),
     vig_depth = dir_depth(vig_path),


### PR DESCRIPTION
Addresses #440. Only the vignette-building functions are changed; no changes are necessary for, e.g., `index.rmd` to be recognized and take precedence over `README.md` (see the branch [rmd-extension-revert-test](https://github.com/corybrunson/pkgdown/tree/rmd-extension-revert-test) for illustration).